### PR TITLE
Env removed from local and added to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+.env


### PR DESCRIPTION
We need to hide our environment files from repos. Sometimes it stores credential data and keys. Someone can use it for bad things🤪